### PR TITLE
Allow digest_file ref from existing image, in lieu of tag_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Create, annotate, and push the manifest. The resulting version is the manifest's
 
     * `tag_file`: a tag file
 
+    * `digest_file`: a tag file (alternate to `tag_file`, useful to reference a `docker-image-resource` `digest` file)
+
 ## Example
 
 ```yaml
@@ -59,4 +61,19 @@ jobs:
         - arch: amd64
           os: linux
           tag_file: build/tag
+
+- name: build manifest from existing image
+  plan:
+  - get: some-image-amd64
+  - get: some-image-arm64
+  - put: image-manifest
+      params:
+        tag_file: version/version
+        manifests:
+        - arch: amd64
+          os: linux
+          digest_file: some-image-amd64/digest
+        - arch: arm64
+          os: linux
+          digest_file: some-image-arm64/digest
 ```

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -30,9 +30,10 @@ type Params struct {
 }
 
 type Manifest struct {
-	Arch    string `json:"arch"`
-	OS      string `json:"os"`
-	TagFile string `json:"tag_file"`
+	Arch       string `json:"arch"`
+	OS         string `json:"os"`
+	TagFile    string `json:"tag_file"`
+	DigestFile string `json:"digest_file"`
 }
 
 func main() {
@@ -59,12 +60,21 @@ func main() {
 	fmt.Fprintf(os.Stderr, "manifest list: %s\n", manifestList)
 	var manifests []string
 	var annotations []manifest.Annotation
+	var ref string
 	for _, m := range request.Params.Manifests {
-		tag, err := readTag(m.TagFile)
-		if err != nil {
-			log.Fatalf("cannot read tag: %v", err)
+		if len(m.DigestFile) > 0 {
+			digest, err := readTag(m.DigestFile)
+			if err != nil {
+				log.Fatalf("cannot read tag: %v", err)
+			}
+			ref = request.Source.Repository + "@" + digest
+		} else {
+			tag, err := readTag(m.TagFile)
+			if err != nil {
+				log.Fatalf("cannot read tag: %v", err)
+			}
+			ref = request.Source.Repository + ":" + tag
 		}
-		ref := request.Source.Repository + ":" + tag
 		fmt.Fprintf(os.Stderr, "manifest, ref: %s, arch: %s, os: %s\n", ref, m.Arch, m.OS)
 		manifests = append(manifests, ref)
 		annotations = append(annotations, manifest.Annotation{


### PR DESCRIPTION
This PR is published as image `drnic/concourse-docker-manifest-resource:latest`

```yaml
resource_types:
- name: docker-manifest
  type: docker-image
  source:
    # repository: mbialon/concourse-docker-manifest-resource
    repository: drnic/concourse-docker-manifest-resource
```