### PR TITLE
store digest in file

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -43,4 +43,12 @@ func main() {
 	if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {
 		log.Fatalf("cannot encode output: %v", err)
 	}
+	file, err := os.Create("digest")
+	if err != nil {
+		log.Fatalf("cannot create digest file: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := fmt.Fprintln(file, request.Version.Digest); err != nil {
+		log.Fatalf("cannot write digest: %v", err)
+	}
 }


### PR DESCRIPTION
This pull requests makes the resource store the digest of the pushed manifest in a file called `digest` just like the docker-image resource, so a follow up task can pick up the result.