### PR TITLE
Allow private registries

### DIFF
--- a/cmd/in/main.go
+++ b/cmd/in/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/mbialon/concourse-docker-manifest-resource/pkg/docker"
 	"log"
 	"os"
 	"strings"
@@ -32,6 +33,9 @@ func main() {
 	var request Request
 	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
 		log.Fatalf("cannot decode input: %v", err)
+	}
+	if err := docker.Login(request.Source.Username, request.Source.Password, request.Source.Repository); err != nil {
+		log.Fatalf("cannot login to docker registry: %v", err)
 	}
 	manifestList := fmt.Sprintf("%s@%s", strings.TrimSpace(request.Source.Repository), request.Version.Digest)
 	if err := manifest.Inspect(manifestList); err != nil {

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -54,8 +54,8 @@ func main() {
 		}
 	}
 	fmt.Fprintf(os.Stderr, "source, repository: %s, tag: %s\n", request.Source.Repository, tag)
-	if err := docker.Login(request.Source.Username, request.Source.Password); err != nil {
-		log.Fatalf("cannot login to docker hub: %v", err)
+	if err := docker.Login(request.Source.Username, request.Source.Password, request.Source.Repository); err != nil {
+		log.Fatalf("cannot login to docker registry: %v", err)
 	}
 	manifestList := request.Source.Repository + ":" + tag
 	fmt.Fprintf(os.Stderr, "manifest list: %s\n", manifestList)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -3,10 +3,67 @@ package docker
 import (
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 )
 
-func Login(username, password string) error {
-	cmd := exec.Command("docker", "login", "-u", username, "-p", password)
+func Login(username, password, repository string) error {
+	args := []string{"login", "-u", username, "-p", password}
+
+	if private, server := isPrivateRegistry(repository); private {
+		args = append(args, server)
+	}
+
+	cmd := exec.Command("docker", args...)
 	cmd.Stderr = os.Stderr
+
 	return cmd.Run()
+}
+
+func isPrivateRegistry(repository string) (bool, string) {
+	ok, repositoryPrefix := hasPrefix(repository)
+
+	switch {
+	case !ok:
+		return false, ""
+
+	case hasPortSuffix(repositoryPrefix):
+		return true, repositoryPrefix
+
+	case looksLikeDnsName(repositoryPrefix):
+		return true, repositoryPrefix
+
+	default:
+		return false, ""
+	}
+}
+
+func hasPrefix(repository string) (bool, string) {
+	parts := strings.Split(repository, "/")
+	if len(parts) < 2 {
+		return false, ""
+	}
+
+	return true, parts[0]
+}
+
+func hasPortSuffix(repositoryPrefix string) bool {
+	parts := strings.Split(repositoryPrefix, ":")
+	if len(parts) < 2 {
+		return false
+	}
+
+	suffix := parts[len(parts)-1]
+	val, err := strconv.ParseInt(suffix, 10, 32)
+	if err != nil {
+		return false
+	}
+
+	return suffix == strconv.FormatInt(val, 10)
+}
+
+func looksLikeDnsName(repositoryPrefix string) bool {
+	parts := strings.Split(repositoryPrefix, ".")
+
+	return len(parts) > 1
 }


### PR DESCRIPTION
This commit changes the execution of the `docker login` command to supply the registry when the repository is hosted in a private registry.

A private registry is assumed when
- there is at least one slash in the repository name
- and the word before the first slash either ends in a port like `localhost:5000` or looks like a DNS name like `registry.cloud.example.com`.

Without this PR the resource only works with Docker Hub.